### PR TITLE
Move LogHelper into hxp project file documentation

### DIFF
--- a/command-line_tools/project_files/hxp_format.md
+++ b/command-line_tools/project_files/hxp_format.md
@@ -293,3 +293,8 @@ Use the `path` method to add directories to your system's PATH environment varia
 
     path ("path/to/add/to/system/PATH");
 
+## LogHelper.error
+
+Use `LogHelper.error` to throw your own errors during the build process, if necessary.
+
+    LogHelper.error ("Something is wrong");

--- a/command-line_tools/project_files/xml_format.md
+++ b/command-line_tools/project_files/xml_format.md
@@ -243,9 +243,3 @@ Use `<dependency />` tags to specify native frameworks or references that are re
 Use `<path />` tags to add directories to your system's PATH environment variable.
 
     <path value="path/to/add/to/system/PATH" />
-
-### LogHelper.error
-
-Use `LogHelper.error` to throw your own errors during the build process, if necessary.
-
-    LogHelper.error ("Something is wrong");


### PR DESCRIPTION
In the xml project format documentation at the end of the page it talks about `LogHelper.error` which is not a valid xml tag ;)
Most likely it's supposed to be in hxp_format.md