### PR TITLE
Version bump of download links to 3.2.1

### DIFF
--- a/getting_started/installing_openfl.md
+++ b/getting_started/installing_openfl.md
@@ -4,9 +4,9 @@
 
 First, you will need to install Haxe and Neko. OpenFL uses Haxe to power the build process, and Neko to run the command-line tools. Both are included in the following installers, one for each platform:
 
- * [Windows](http://haxe.org/file/haxe-3.1.3-win.exe)
- * [Mac](http://haxe.org/file/haxe-3.1.3-osx-installer.pkg)
- * [Linux](http://www.openfl.org/builds/haxe/haxe-3.1.3-linux-installer.tar.gz)
+ * [Windows](http://haxe.org/download/file/3.2.1/haxe-3.2.1-win.exe)
+ * [Mac](http://haxe.org/download/file/3.2.1/haxe-3.2.1-osx-installer.pkg)
+ * [Linux](http://www.openfl.org/builds/haxe/haxe-3.2.1-linux-installer.tar.gz)
 
 _If you are a Linux user, we recommend that you do use the above install script instead of your own package manager. The versions of Haxe and Neko distributed on Linux package repositories tend to be old, or experience other issues after the install._
 


### PR DESCRIPTION
Also it'd be nice if there was some explanation for the conflicting advice between this page (don't use your package manager) and the official Haxe advice at http://haxe.org/download/linux which says, "The Haxe Foundation officially participates in the maintenance of Haxe and Neko packages for a number of popular Linux distributions. It is recommended to use those packages if available."  Is OpenFL's advice out of date, or is there a special reason to override Haxe's advice?  If the former we should remove it, if the latter I think it would be less confusing if an explicit note of the discrepancy and reasoning for it were included here.